### PR TITLE
Added the option to let 'changelog show' not wrap the output.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.7.2 (????-??-??)
+------------------
+
+* Here's a super long line thats meant to wrap to the next line. Hopefully this
+  will happen
+
+
 0.7.1 (2023-02-14)
 ------------------
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,8 +4,9 @@ Changelog
 0.7.2 (????-??-??)
 ------------------
 
-* Here's a super long line thats meant to wrap to the next line. Hopefully this
-  will happen
+* Added a `--nowrap` option to `show`, which doesn't wrap long lines. This is
+  useful for copy-pasting changelog into places where linebreaks are
+  significant, such as the Github releases section.
 
 
 0.7.1 (2023-02-14)

--- a/changelog.mjs
+++ b/changelog.mjs
@@ -116,15 +116,28 @@ export class VersionLog {
 
   toString() {
 
+    return this.output();
+
+  }
+
+  /**
+   * Renders the changelog as a string.
+   *
+   * @param {boolean} lineWrap
+   * @returns {string}
+   */
+  output(lineWrap = true) {
+
+    const lineLength = lineWrap ? 79 : Infinity;
     const title = this.version + ' (' + (this.date ?? '????-??-??') + ')';
     return (
       title + '\n' +
       ('-'.repeat(title.length)) + '\n' +
-      (this.preface ? '\n' + wrap(this.preface) : '') +
+      (this.preface ? '\n' + wrap(this.preface, 0, lineLength) : '') +
       '\n' +
-      this.items.map(version => version.toString()).join('\n') +
+      this.items.map(version => version.output(lineWrap)).join('\n') +
       '\n' +
-      (this.postface ? '\n' + wrap(this.postface) + '\n' : '')
+      (this.postface ? '\n' + wrap(this.postface, 0, lineLength) + '\n' : '')
     );
 
   }
@@ -143,6 +156,17 @@ export class LogItem {
    */
   constructor(message) {
     this.message = message;
+  }
+
+  /**
+   * Renders the changelog as a string.
+   *
+   * @param {boolean} lineWrap
+   * @returns {string}
+   */
+  output(lineWrap = true) {
+    const lineLength = lineWrap ? 79 : Infinity;
+    return wrap('* ' + this.message, 2, lineLength);
   }
 
   toString() {

--- a/cli.mjs
+++ b/cli.mjs
@@ -49,6 +49,10 @@ async function main() {
         type: 'boolean',
         description: 'Indicates that the current change is a major change.',
       },
+      nowrap: {
+        type: 'boolean',
+        description: 'Don\'t wrap "show" output'
+      }
     },
     allowPositionals: true,
   });
@@ -93,7 +97,11 @@ async function main() {
       await format();
       break;
     case 'show' :
-      await show({ all: !!values.all, version: positionals[1]});
+      await show({
+        all: !!values.all,
+        version: positionals[1],
+        noWrap: !!values.nowrap
+      });
       break;
     case 'list' :
       await list();
@@ -170,8 +178,9 @@ async function list() {
  * @param {Object} showOptions
  * @param {boolean} showOptions.all Show all versions
  * @param {string?} showOptions.version show a specific version
+ * @param {boolean?} showOptions.noWrap don't line-wrap output
  */
-async function show({all, version}) {
+async function show({all, version, noWrap}) {
 
   const changelog = await parseChangelog();
 
@@ -186,7 +195,7 @@ async function show({all, version}) {
 
   console.log(
     toRender
-      .map( log => log.toString())
+      .map( log => log.output(!noWrap))
       .join('\n\n')
   );
 


### PR DESCRIPTION
This is handy for copy-pasting into github releases where whitespace is significant.