### PR TITLE
Markdown reference links

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+0.8.0 (????-??-??)
+------------------
+
+* Add support for [Markdown reference links][1]. Rferences are a Markdown
+  feature that lets you write links in paragraphs, but put the actual target
+  near the end of the document similar to references in technical documents.
+  This can declutter the reading experience for those reading the Markdown
+  sources. The tool doesn't let you quickly add links via the CLI yet, but it
+  will no longer mangle them when they appear.
+
+
 0.7.2 (2023-02-17)
 ------------------
 
@@ -71,3 +82,6 @@ Changelog
 ------------------
 
 * Implemented the 'help' and 'init' commands.
+
+[1]: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links
+     "Markdown cheatsheet: Links"

--- a/changelog.mjs
+++ b/changelog.mjs
@@ -10,13 +10,21 @@ export class Changelog {
    */
   versions = [];
 
+  /**
+   * @type {Link[]}
+   */
+  links = [];
+
   toString() {
 
     return (
       this.title + '\n' +
       ('='.repeat(this.title.length)) + '\n' +
       '\n' +
-      this.versions.map(version => version.toString()).join('\n\n')
+      this.versions.map(version => version.toString()).join('\n\n') +
+
+      // Sorry about this line future me (or someone else)
+      (this.links.length > 0 ? ('\n' + this.links.map( link => wrap(`[${link.name}]: ${link.href}${link.title?` "${link.title}"`:''}`, link.name.length+4)).join('\n') + '\n') : '')
     );
 
   }
@@ -147,7 +155,7 @@ export class VersionLog {
 export class LogItem {
 
   /**
-   * @type string
+   * @type {string}
    */
   message;
 
@@ -177,4 +185,9 @@ export class LogItem {
 
 }
 
-
+/**
+ * @typedef Link {Object}
+ * @property Link.href {string}
+ * @property Link.name {string}
+ * @property Link.title {string|null}
+ */

--- a/test/parse.mjs
+++ b/test/parse.mjs
@@ -83,7 +83,6 @@ Well, that's all folks.
 *
 `;
 
-  debugger;
   const result = await parse(input);
 
   const latest = result.get('0.2.0');
@@ -91,5 +90,46 @@ Well, that's all folks.
   assert.equal('WOW another release. How good is that? Here\'s another line.', latest.preface);
   assert.equal('Well, that\'s all folks.', latest.postface);
 
+
+});
+
+test('Link references', async() => {
+
+
+  const input = `Changesss
+=========
+
+0.2.0 (????-??-??)
+------------------
+
+WOW another release. How good is that?
+Here's another line.
+
+* Implemented the 'list' command.
+* Added testing framework. See [the blog post][1] for more information.
+
+0.1.0 (2023-02-08)
+------------------
+
+* Implemented the ['help'][2] and 'init' commands.
+
+[1]: https://evertpot.com/ "My Blog"
+[2]: https://indieweb.social/@evert "My Mastodon account, but it's split
+  over two lines"
+`;
+
+  debugger;
+  const result = await parse(input);
+
+  assert.deepEqual({
+    name: '1',
+    href: 'https://evertpot.com/',
+    title: 'My Blog',
+  }, result.links[0]);
+  assert.deepEqual({
+    name: '2',
+    href: 'https://indieweb.social/@evert',
+    title: 'My Mastodon account, but it\'s split over two lines',
+  }, result.links[1]);
 
 });


### PR DESCRIPTION
Add support for [Markdown reference links][1]. Rferences are a Markdown
  feature that lets you write links in paragraphs, but put the actual target
  near the end of the document similar to references in technical documents.
  This can declutter the reading experience for those reading the Markdown
  sources. The tool doesn't let you quickly add links via the CLI yet, but it
  will no longer mangle them when they appear.

[1]: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links    
     "Markdown cheatsheet: Links"                                              
