### PR TITLE
Ignore untracked files in release command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.3.0 (????-??-??)
+------------------
+
+* #14 git release will no longer complain about untracked files in a repo, and
+  will no longer add all files before comitting.
+
+
 1.2.1 (2025-05-26)
 ------------------
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@ Changelog
 ------------------
 
 * #14 git release will no longer complain about untracked files in a repo, and
-  will no longer add all files before comitting.
+  will no longer add all files before committing.
 
 
 1.2.1 (2025-05-26)

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-1.3.0 (????-??-??)
+1.3.0 (2026-02-18)
 ------------------
 
 * #14 git release will no longer complain about untracked files in a repo, and

--- a/cli.mjs
+++ b/cli.mjs
@@ -275,7 +275,7 @@ async function release(force = false) {
     );
   }
   if (useGit) {
-    runCommand(`git add --all`);
+    runCommand(`git add --update`);
     runCommand(`git commit -m "Releasing ${lastVersion.version}"`);
     runCommand(`git tag v${lastVersion.version}`);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "changelog-tool",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "changelog-tool",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "bin": {
         "changelog": "cli.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "changelog-tool",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A CLI tool for manipulating changelogs",
   "type": "module",
   "main": "index.mjs",

--- a/util.mjs
+++ b/util.mjs
@@ -148,6 +148,7 @@ export function runCommand(command) {
 export function isGitClean() {
 
   const result = execSync('git status --porcelain=v1').toString('utf-8');
-  return result.trim().length === 0;
+  const trackedChanges = result.split('\n').filter(line => line.length > 0 && !line.startsWith('??'));
+  return trackedChanges.length === 0;
 
 }


### PR DESCRIPTION
The git clean check now ignores untracked files (lines starting with '??'
in git status output). The commit step also switches from 'git add --all'
to 'git add --update' so untracked files are never staged.

Fixes #14